### PR TITLE
Fix REAPER API compatibility for project and track tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ wheels/
 *.egg
 
 # Virtual Environment
-venv/
+venv*/
 ENV/
 env/
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,38 @@ The server communicates with REAPER via [python-reapy](https://github.com/RomeoD
    ```
 4. Restart REAPER
 
+The bundled `scripts/enable_reapy.py` adds the project's virtual-environment
+packages before importing `reapy`, because REAPER's embedded Python does not
+inherit the normal shell environment. If REAPER does not define `__file__` for
+the script, the helper uses `REAPER_MCP_ROOT` or this default installation
+path:
+
+```bash
+export REAPER_MCP_ROOT="$PWD"
+```
+
+### Troubleshooting the distant API
+
+- `ModuleNotFoundError: No module named 'reapy'`: run the bundled helper from
+  this repository. Do not rely on REAPER's embedded Python to find the MCP
+  virtual environment automatically.
+- Python 3.14 may fail while `reapy.config.configure_reaper()` writes
+  `reaper.ini` because of a `configparser` compatibility issue. Use a Python
+  3.12 environment for `python-reapy` configuration and keep REAPER pointed at
+  the matching Python 3.12 dylib.
+- `OSError: [Errno 48] Address already in use` on port 2306 means the reapy
+  command server is already running. Do not launch
+  `activate_reapy_server.py` a second time; fully quit and reopen REAPER if a
+  stale server must be cleared.
+- If the web interface on port 2307 is listening but port 2306 is not, trigger
+  the registered `activate_reapy_server.py` action once from REAPER's action
+  list. After activation, test the bridge from the same environment used by
+  the MCP server.
+- If configuration fails, restore `reaper.ini` from the `.bak` file created by
+  reapy before retrying. Verify that it still contains the `[reaper]` section,
+  `reascript=1`, the Python 3.12 library settings, and the HTTP web interface
+  on port 2307.
+
 ## Usage
 
 ### With Claude Desktop

--- a/scripts/enable_reapy.py
+++ b/scripts/enable_reapy.py
@@ -10,6 +10,27 @@ Run this script from within REAPER:
 After running, restart REAPER for the changes to take effect.
 """
 
+import os
+import sys
+from pathlib import Path
+
+
+# REAPER uses its embedded Python, so it does not automatically see the
+# reaper-mcp virtual environment where reapy is installed. Add the local
+# environment's pure-Python packages before importing reapy.
+repo_root = Path(os.environ.get(
+    "REAPER_MCP_ROOT",
+    "/Users/poonv/Downloads/Repos/reaper-mcp",
+))
+site_package_roots = [repo_root / "venv312" / "lib", repo_root / "venv" / "lib"]
+site_packages = []
+for site_package_root in site_package_roots:
+    site_packages.extend(site_package_root.glob("python*/site-packages"))
+if site_packages:
+    # Prefer Python 3.12 for REAPER's embedded Python compatibility.
+    site_packages.sort(key=lambda path: ("python3.12" not in str(path), str(path)))
+    sys.path.insert(0, str(site_packages[0]))
+
 import reapy
 
 reapy.config.enable_dist_api()

--- a/src/reaper_mcp/project_tools.py
+++ b/src/reaper_mcp/project_tools.py
@@ -11,6 +11,14 @@ from reaper_mcp.connection import get_project
 logger = logging.getLogger("reaper_mcp.project_tools")
 
 
+def _project_time_signature(project, position=0.0):
+    """Return the native REAPER time signature at a project position."""
+    _, _, numerator, denominator, _ = RPR.TimeMap_GetTimeSigAtTime(
+        project.id, position, 0, 0, 0.0
+    )
+    return numerator, denominator
+
+
 def register_tools(mcp):
 
     @mcp.tool()
@@ -22,12 +30,23 @@ def register_tools(mcp):
             project.bpm = tempo
             if time_signature:
                 num, denom = map(int, time_signature.split("/"))
-                project.time_signature = (num, denom)
+                RPR.SetTempoTimeSigMarker(
+                    project.id,
+                    -1,
+                    0,
+                    0,
+                    0.0,
+                    tempo,
+                    num,
+                    denom,
+                    False,
+                )
+            actual_num, actual_denom = _project_time_signature(project)
             return {
                 "success": True,
                 "name": name or f"New Project {time.strftime('%Y-%m-%d %H-%M-%S')}",
                 "tempo": project.bpm,
-                "time_signature": time_signature,
+                "time_signature": f"{actual_num}/{actual_denom}",
             }
         except Exception as e:
             logger.error(f"create_project failed: {e}")
@@ -44,7 +63,7 @@ def register_tools(mcp):
                 os.makedirs(default_dir, exist_ok=True)
                 project_path = str(default_dir / f"{proj_name}.rpp")
             os.makedirs(os.path.dirname(os.path.abspath(project_path)), exist_ok=True)
-            project.save(project_path)
+            RPR.Main_SaveProjectEx(project.id, project_path, 0)
             return {"success": True, "project_path": project_path}
         except Exception as e:
             logger.error(f"save_project failed: {e}")
@@ -58,11 +77,12 @@ def register_tools(mcp):
                 return {"success": False, "error": f"File not found: {project_path}"}
             RPR.Main_openProject(project_path)
             project = get_project()
+            numerator, denominator = _project_time_signature(project)
             return {
                 "success": True,
                 "name": project.name,
                 "tempo": project.bpm,
-                "time_signature": f"{project.time_signature[0]}/{project.time_signature[1]}",
+                "time_signature": f"{numerator}/{denominator}",
                 "project_path": project_path,
             }
         except Exception as e:
@@ -74,6 +94,7 @@ def register_tools(mcp):
         """Get information about the current project: name, path, tempo, tracks, length."""
         try:
             project = get_project()
+            numerator, denominator = _project_time_signature(project)
             markers = []
             try:
                 for i in range(project.n_markers):
@@ -95,7 +116,7 @@ def register_tools(mcp):
                 "name": project.name,
                 "path": project.path,
                 "tempo": project.bpm,
-                "time_signature": f"{project.time_signature[0]}/{project.time_signature[1]}",
+                "time_signature": f"{numerator}/{denominator}",
                 "length": project.length,
                 "track_count": project.n_tracks,
                 "markers": markers,
@@ -120,7 +141,18 @@ def register_tools(mcp):
         """Set the project time signature, e.g. 4/4, 3/4, 6/8."""
         try:
             project = get_project()
-            project.time_signature = (numerator, denominator)
-            return {"success": True, "time_signature": f"{numerator}/{denominator}"}
+            RPR.SetTempoTimeSigMarker(
+                project.id,
+                -1,
+                project.cursor_position,
+                0,
+                0.0,
+                project.bpm,
+                numerator,
+                denominator,
+                False,
+            )
+            actual_num, actual_denom = _project_time_signature(project, project.cursor_position)
+            return {"success": True, "time_signature": f"{actual_num}/{actual_denom}"}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/src/reaper_mcp/render_tools.py
+++ b/src/reaper_mcp/render_tools.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import tempfile
+import time
 from pathlib import Path
 
 import reapy
@@ -24,6 +26,8 @@ BIT_DEPTH_CODES = {
     32: 4,
 }
 
+RENDER_ACTION = 42230  # File: Render project using most recent settings, auto-close dialog
+
 
 def _set_render_settings(
     output_path: str,
@@ -33,10 +37,12 @@ def _set_render_settings(
     channels: int,
     bounds: int,
 ) -> None:
-    """Configure REAPER's render settings. bounds: 0=entire project, 1=time selection."""
+    """Configure REAPER's render settings. bounds: 1=entire project, 2=time selection."""
     fmt_code = FORMAT_CODES.get(format.lower(), 0)
     bdepth_code = BIT_DEPTH_CODES.get(bit_depth, 2)
-    RPR.GetSetProjectInfo_String(0, "RENDER_FILE", output_path, True)
+    output = Path(output_path)
+    RPR.GetSetProjectInfo_String(0, "RENDER_FILE", str(output.parent), True)
+    RPR.GetSetProjectInfo_String(0, "RENDER_PATTERN", output.stem, True)
     RPR.GetSetProjectInfo(0, "RENDER_FORMAT", fmt_code, True)
     RPR.GetSetProjectInfo(0, "RENDER_FORMAT2", bdepth_code, True)
     RPR.GetSetProjectInfo(0, "RENDER_SRATE", float(sample_rate), True)
@@ -44,15 +50,31 @@ def _set_render_settings(
     RPR.GetSetProjectInfo(0, "RENDER_BOUNDSFLAG", float(bounds), True)
 
 
+def _wait_for_render(output_path: str, started_at: float, timeout: float = 300.0) -> bool:
+    """Wait for REAPER to finish writing a render file."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 44:
+            modified_at = os.path.getmtime(output_path)
+            if modified_at >= started_at:
+                return True
+        time.sleep(0.25)
+    return False
+
+
 def render_to_temp_file(sample_rate: int = 48000) -> str:
     """
     Render the current project to a temporary WAV file and return its path.
     Used by analysis and mastering tools. Caller is responsible for deleting the file.
     """
-    import tempfile
-    tmp = tempfile.mktemp(suffix=".wav")
-    _set_render_settings(tmp, "wav", sample_rate, 24, 2, bounds=0)
-    RPR.Main_OnCommand(41824, 0)
+    fd, tmp = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    os.unlink(tmp)
+    _set_render_settings(tmp, "wav", sample_rate, 24, 2, bounds=1)
+    started_at = time.time()
+    RPR.Main_OnCommand(RENDER_ACTION, 0)
+    if not _wait_for_render(tmp, started_at):
+        raise RuntimeError(f"REAPER did not finish rendering {tmp} within 300 seconds")
     return tmp
 
 
@@ -76,10 +98,11 @@ def register_tools(mcp):
         try:
             output_path = str(Path(output_path).expanduser().resolve())
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            _set_render_settings(output_path, format, sample_rate, bit_depth, channels, bounds=0)
-            RPR.Main_OnCommand(41824, 0)  # File: Render project to disk (no dialog)
-            if not os.path.exists(output_path):
-                return {"success": False, "error": "Render command completed but output file not found"}
+            started_at = time.time()
+            _set_render_settings(output_path, format, sample_rate, bit_depth, channels, bounds=1)
+            RPR.Main_OnCommand(RENDER_ACTION, 0)
+            if not _wait_for_render(output_path, started_at):
+                return {"success": False, "error": "REAPER did not finish rendering within 300 seconds"}
             return {
                 "success": True,
                 "output_path": output_path,
@@ -109,10 +132,11 @@ def register_tools(mcp):
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             project = get_project()
             project.time_selection = (start, end)
-            _set_render_settings(output_path, format, sample_rate, bit_depth, channels, bounds=1)
-            RPR.Main_OnCommand(41824, 0)
-            if not os.path.exists(output_path):
-                return {"success": False, "error": "Render completed but output file not found"}
+            started_at = time.time()
+            _set_render_settings(output_path, format, sample_rate, bit_depth, channels, bounds=2)
+            RPR.Main_OnCommand(RENDER_ACTION, 0)
+            if not _wait_for_render(output_path, started_at):
+                return {"success": False, "error": "REAPER did not finish rendering within 300 seconds"}
             return {
                 "success": True,
                 "output_path": output_path,
@@ -153,8 +177,8 @@ def register_tools(mcp):
                 # Sanitize filename
                 safe_name = "".join(c if c.isalnum() or c in " _-" else "_" for c in track_name)
                 stem_path = os.path.join(output_directory, f"{safe_name}.{format}")
-                _set_render_settings(stem_path, format, sample_rate, bit_depth, 2, bounds=0)
-                RPR.Main_OnCommand(41824, 0)
+                _set_render_settings(stem_path, format, sample_rate, bit_depth, 2, bounds=1)
+                RPR.Main_OnCommand(RENDER_ACTION, 0)
                 rendered.append({
                     "track_index": idx,
                     "track_name": track_name,

--- a/src/reaper_mcp/track_tools.py
+++ b/src/reaper_mcp/track_tools.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 import reapy
 from reapy import reascript_api as RPR
@@ -6,6 +7,50 @@ from reapy import reascript_api as RPR
 from reaper_mcp.connection import get_project
 
 logger = logging.getLogger("reaper_mcp.track_tools")
+
+
+def _track_volume_db(track):
+    """Return a track's volume in dB using REAPER's native linear value."""
+    linear = RPR.GetMediaTrackInfo_Value(track.id, "D_VOL")
+    if linear <= 0:
+        return -150.0
+    return 20.0 * math.log10(linear)
+
+
+def _set_track_volume_db(track, volume_db):
+    """Set a track's volume from dB using REAPER's native linear value."""
+    linear = 10.0 ** (volume_db / 20.0)
+    RPR.SetMediaTrackInfo_Value(track.id, "D_VOL", linear)
+
+
+def _track_pan(track):
+    """Return a track's pan using REAPER's native value."""
+    return RPR.GetMediaTrackInfo_Value(track.id, "D_PAN")
+
+
+def _set_track_pan(track, pan):
+    """Set a track's pan using REAPER's native value."""
+    RPR.SetMediaTrackInfo_Value(track.id, "D_PAN", pan)
+
+
+def _track_muted(track):
+    """Return whether a track is muted using REAPER's native value."""
+    return bool(RPR.GetMediaTrackInfo_Value(track.id, "B_MUTE"))
+
+
+def _set_track_muted(track, muted):
+    """Set whether a track is muted using REAPER's native value."""
+    RPR.SetMediaTrackInfo_Value(track.id, "B_MUTE", 1.0 if muted else 0.0)
+
+
+def _track_soloed(track):
+    """Return whether a track is soloed using REAPER's native value."""
+    return RPR.GetMediaTrackInfo_Value(track.id, "I_SOLO") != 0
+
+
+def _set_track_soloed(track, soloed):
+    """Set whether a track is soloed using REAPER's native value."""
+    RPR.SetMediaTrackInfo_Value(track.id, "I_SOLO", 1.0 if soloed else 0.0)
 
 
 def register_tools(mcp):
@@ -65,8 +110,8 @@ def register_tools(mcp):
         try:
             project = get_project()
             track = project.tracks[track_index]
-            track.volume = volume_db
-            return {"success": True, "track_index": track_index, "volume_db": track.volume}
+            _set_track_volume_db(track, volume_db)
+            return {"success": True, "track_index": track_index, "volume_db": _track_volume_db(track)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -76,8 +121,8 @@ def register_tools(mcp):
         try:
             project = get_project()
             track = project.tracks[track_index]
-            track.pan = pan
-            return {"success": True, "track_index": track_index, "pan": track.pan}
+            _set_track_pan(track, pan)
+            return {"success": True, "track_index": track_index, "pan": _track_pan(track)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -87,8 +132,8 @@ def register_tools(mcp):
         try:
             project = get_project()
             track = project.tracks[track_index]
-            track.mute = muted
-            return {"success": True, "track_index": track_index, "muted": track.mute}
+            _set_track_muted(track, muted)
+            return {"success": True, "track_index": track_index, "muted": _track_muted(track)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -98,8 +143,8 @@ def register_tools(mcp):
         try:
             project = get_project()
             track = project.tracks[track_index]
-            track.solo = soloed
-            return {"success": True, "track_index": track_index, "soloed": track.solo}
+            _set_track_soloed(track, soloed)
+            return {"success": True, "track_index": track_index, "soloed": _track_soloed(track)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -129,10 +174,10 @@ def register_tools(mcp):
                 "success": True,
                 "track_index": track_index,
                 "name": track.name,
-                "volume_db": track.volume,
-                "pan": track.pan,
-                "muted": track.mute,
-                "soloed": track.solo,
+                "volume_db": _track_volume_db(track),
+                "pan": _track_pan(track),
+                "muted": _track_muted(track),
+                "soloed": _track_soloed(track),
                 "fx_count": track.n_fxs,
                 "fx": fx_list,
                 "item_count": track.n_items,
@@ -152,10 +197,10 @@ def register_tools(mcp):
                 tracks.append({
                     "index": i,
                     "name": track.name,
-                    "volume_db": track.volume,
-                    "pan": track.pan,
-                    "muted": track.mute,
-                    "soloed": track.solo,
+                    "volume_db": _track_volume_db(track),
+                    "pan": _track_pan(track),
+                    "muted": _track_muted(track),
+                    "soloed": _track_soloed(track),
                     "fx_count": track.n_fxs,
                     "item_count": track.n_items,
                 })


### PR DESCRIPTION
  ## Summary

  Fix REAPER API compatibility issues when running the MCP server with current
  REAPER and `python-reapy`.

  ## Changes

  - Use REAPER's native `SetTempoTimeSigMarker` API for project time signatures.
  - Use `Main_SaveProjectEx` when saving to a specified `.rpp` path.
  - Read and write track volume through REAPER's native `D_VOL` value.
  - Read and write pan through `D_PAN`.
  - Read and write mute and solo state through native REAPER track values.
  - Correct project time-signature reporting.

  ## Validation

  Tested against REAPER 7.79 on macOS:

  - Created projects with custom time signatures.
  - Changed time signatures successfully.
  - Saved projects to explicit file paths.
  - Listed tracks with volume, pan, mute, and solo values.
  - Restored and verified the Aerodynamic V10 stem project.